### PR TITLE
added toggle block to single comment when single config is nil

### DIFF
--- a/lua/nvim-commaround/commaround.lua
+++ b/lua/nvim-commaround/commaround.lua
@@ -69,7 +69,6 @@ end
 local function toggle_single(filetype_config, context)
    if filetype_config['single'] == nil then
 	  toggle_block(filetype_config, context)
-	  return nil
    end
    if not is_comment_single(filetype_config) then
 	  vim.cmd('norm ^i'..filetype_config['single']..' ')

--- a/lua/nvim-commaround/commaround.lua
+++ b/lua/nvim-commaround/commaround.lua
@@ -69,6 +69,7 @@ end
 local function toggle_single(filetype_config, context)
    if filetype_config['single'] == nil then
 	  toggle_block(filetype_config, context)
+	  return nil
    end
    if not is_comment_single(filetype_config) then
 	  vim.cmd('norm ^i'..filetype_config['single']..' ')

--- a/lua/nvim-commaround/commaround.lua
+++ b/lua/nvim-commaround/commaround.lua
@@ -66,9 +66,9 @@ local function toggle_block(filetype_config, context)
    end
 end
 
-local function toggle_single(filetype_config)
+local function toggle_single(filetype_config, context)
    if filetype_config['single'] == nil then
-	  print('no single line comment available')
+	  toggle_block(filetype_config, context)
 	  return nil
    end
    if not is_comment_single(filetype_config) then

--- a/lua/nvim-commaround/config.lua
+++ b/lua/nvim-commaround/config.lua
@@ -22,6 +22,7 @@ local config = {
    tex = {single = "%", block = nil},
    typescript = {single = "//", block = {left = "/*", right = "*/"}},
    vim = {single = "\"", block = nil},
+   xml = {single = nil, block = {left = "<!--", right = "-->"}},
 }
 
 return {

--- a/lua/nvim-commaround/init.lua
+++ b/lua/nvim-commaround/init.lua
@@ -18,7 +18,7 @@ local function toggle_comment()
    if #lines > 1 then
 	  comments.toggle_block(filetype_config, context)
    else
-	  comments.toggle_single(filetype_config)
+	  comments.toggle_single(filetype_config, context)
    end
 end
 


### PR DESCRIPTION
- trying to address issue https://github.com/gennaro-tedesco/nvim-commaround/issues/8
- introduced block comment for single lines when single line config is nil