### PR TITLE
feat(config): add `dosbatch` support

### DIFF
--- a/lua/nvim-commaround/config.lua
+++ b/lua/nvim-commaround/config.lua
@@ -5,6 +5,7 @@ local config = {
    cpp = {single = "//", block = {left = "/*", right = "*/"}},
    css = {single = "//", block = {left = "/*", right = "*/"}},
    dockerfile = {single = "##", block = nil},
+   dosbatch = {single = "REM", block = nil},
    gitconfig = {single = "#", block = nil},
    go = {single = "//", block = {left = "/*", right = "*/"}},
    haskell = {single = "--", block = {left = "{-", right = "-}"}},


### PR DESCRIPTION
Add `dosbatch` support for security (Vim's default `::` commentstring may cause errors) and compatibility (with all versions of Windows) reasons. Here is two (the shortest) of the many justifications:

- [tldr](https://stackoverflow.com/a/12407934)
- [generalized](https://stackoverflow.com/a/12408045)